### PR TITLE
remove the need to declare the WEEK environment as empty

### DIFF
--- a/trello-tracker.py
+++ b/trello-tracker.py
@@ -197,7 +197,7 @@ boardid = config.get('trello', 'boardid')
 now = datetime.datetime.now()
 nowiso = now.isocalendar()
 year = nowiso[0]
-if os.environ['WEEK'] != "" :
+if 'WEEK' in os.environ and os.environ['WEEK'] != "" :
     week = os.environ['WEEK']
 else:    
     week = nowiso[1]


### PR DESCRIPTION
this PR will remove the need to declare the WEEK environment variable as empty to use the current week value but will keep the functionality to be able to specify a the desired week in the WEEK environment variable.